### PR TITLE
Fix: queen mobility

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -136,7 +136,10 @@ int mobilityEval(Board* board, int color) {
 
     while(mask) {
         int from = firstOne(mask);
-        U64 possibleMoves = rookPossibleMoves[from][getMagicIndex(occu & rookMagicMask[from] & unSquareBitboard[from], rookMagic[from], rookPossibleMovesSize[from])];
+        U64 possibleMoves = (
+                (rookPossibleMoves[from][getMagicIndex(occu & rookMagicMask[from] & unSquareBitboard[from], rookMagic[from], rookPossibleMovesSize[from])])
+                | (bishopPossibleMoves[from][getMagicIndex(occu & bishopMagicMask[from] & unSquareBitboard[from], bishopMagic[from], bishopPossibleMovesSize[from])])
+        );
         eval += QueenMobility[popcount(possibleMoves & possibleSq)];
         clearBit(&mask, from);
     }


### PR DESCRIPTION
The fix is due to the fact that the queen's mobility did not take into account diagonal squares. This has now been fixed.

```
tc=10+0.1 Hash=256 Threads=1 
LLR: 2.96 (-2.94, 2.94) [0.50, 3.50]
Games: 13504 W: 3967 L: 3695 D: 5842
ELO: 7.00 +- 4.41 (95%) LOS: 99.91%
```