### PR TITLE
Remove TT buckets

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -446,12 +446,9 @@ void moveOrdering(Board *board, U16 *mvs, SearchInfo *searchInfo, int height, in
         movePrice[height][i] = 0;
         U16 toPiece = pieceType(board->squares[MoveTo(*ptr)]);
 
-        for (int j = 0; j < BUCKETS_N; ++j) {
-            if (*ptr == ttEntry->entity[j].move && ttEntry->entity[j].key == board->key) {
-                movePrice[height][i] = 1000000000000000llu + ttEntry->entity[j].depth;
-                isHashMove = 1;
-                break;
-            }
+        if (*ptr == ttEntry->entity[0].move && ttEntry->entity[0].key == board->key) {
+            movePrice[height][i] = 1000000000000000llu + ttEntry->entity[0].depth;
+            isHashMove = 1;
         }
 
         if (isHashMove) {

--- a/src/search.c
+++ b/src/search.c
@@ -118,20 +118,13 @@ int search(Board *board, SearchInfo *searchInfo, int alpha, int beta, int depth,
     U64 keyPosition = board->key;
     Transposition *ttEntry = &tt[keyPosition & ttIndex];
 
-    int bestEntityIndex = getMaxDepthBucket(ttEntry, keyPosition);
-
-    TranspositionEntity *bestEntity = NULL;
-    if (bestEntityIndex != -1) {
-        bestEntity = &ttEntry->entity[bestEntityIndex];
-    }
-
-    if (bestEntity && bestEntity->evalType && bestEntity->depth >= depth && !root) {
-        int ttEval = evalFromTT(bestEntity->eval, height);
+    if (ttEntry && ttEntry->key == board->key && ttEntry->evalType && ttEntry->depth >= depth && !root) {
+        int ttEval = evalFromTT(ttEntry->eval, height);
 
         //TT analysis
-        if ((bestEntity->evalType == lowerbound && ttEval >= beta && !mateScore(bestEntity->eval)) ||
-            (bestEntity->evalType == upperbound && ttEval <= alpha && !mateScore(bestEntity->eval)) ||
-            bestEntity->evalType == exact) {
+        if ((ttEntry->evalType == lowerbound && ttEval >= beta && !mateScore(ttEntry->eval)) ||
+            (ttEntry->evalType == upperbound && ttEval <= alpha && !mateScore(ttEntry->eval)) ||
+            ttEntry->evalType == exact) {
             return ttEval;
         }
     }
@@ -279,7 +272,7 @@ int search(Board *board, SearchInfo *searchInfo, int alpha, int beta, int depth,
     if (ABORT)
         return 0;
 
-    TranspositionEntity new_tt;
+    Transposition new_tt;
     new_tt.depth = depth;
     new_tt.age = ttAge;
     new_tt.evalType = hashType;
@@ -305,19 +298,12 @@ int quiesceSearch(Board *board, SearchInfo *searchInfo, int alpha, int beta, int
     U64 keyPosition = board->key;
     Transposition *ttEntry = &tt[keyPosition & ttIndex];
 
-    int bestEntityIndex = getMaxDepthBucket(ttEntry, keyPosition);
-
-    TranspositionEntity *bestEntity = NULL;
-    if (bestEntityIndex != -1) {
-        bestEntity = &ttEntry->entity[bestEntityIndex];
-    }
-
-    if (bestEntity) {
-        int ttEval = evalFromTT(bestEntity->eval, height);
-        if (bestEntity->evalType) {
-            if ((bestEntity->evalType == lowerbound && ttEval >= beta && !mateScore(bestEntity->eval)) ||
-                (bestEntity->evalType == upperbound && ttEval <= alpha && !mateScore(bestEntity->eval)) ||
-                bestEntity->evalType == exact) {
+    if (ttEntry && ttEntry->key == board->key) {
+        int ttEval = evalFromTT(ttEntry->eval, height);
+        if (ttEntry->evalType) {
+            if ((ttEntry->evalType == lowerbound && ttEval >= beta && !mateScore(ttEntry->eval)) ||
+                (ttEntry->evalType == upperbound && ttEval <= alpha && !mateScore(ttEntry->eval)) ||
+                ttEntry->evalType == exact) {
                 return ttEval;
             }
         }
@@ -446,8 +432,8 @@ void moveOrdering(Board *board, U16 *mvs, SearchInfo *searchInfo, int height, in
         movePrice[height][i] = 0;
         U16 toPiece = pieceType(board->squares[MoveTo(*ptr)]);
 
-        if (*ptr == ttEntry->entity[0].move && ttEntry->entity[0].key == board->key) {
-            movePrice[height][i] = 1000000000000000llu + ttEntry->entity[0].depth;
+        if (*ptr == ttEntry->move && ttEntry->key == board->key) {
+            movePrice[height][i] = 1000000000000000llu + ttEntry->depth;
             isHashMove = 1;
         }
 

--- a/src/search.c
+++ b/src/search.c
@@ -494,8 +494,9 @@ void moveOrdering(Board *board, U16 *mvs, SearchInfo *searchInfo, int height, in
             }
         }
 
-        if (searchInfo->bestMove == *ptr && !height)
+        if (searchInfo->bestMove == *ptr && !height) {
             movePrice[height][i] = 10000000000000000llu;
+        }
 
         ++ptr;
     }

--- a/src/timemanager.h
+++ b/src/timemanager.h
@@ -37,6 +37,5 @@ TimeManager createFixedNodesTm(int depth);
 TimeManager initTM();
 void setTournamentTime(TimeManager* tm, Board* board);
 int testAbort(U64 time, int nodesCount, TimeManager* tm);
-void replaceTranspositionEntry(Transposition* addr, TranspositionEntity* newEntry, U64 key);
 
 #endif

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -28,35 +28,27 @@ void clearTT() {
     ttFilledSize = 0;
 }
 
-void replaceTranspositionEntry(Transposition* addr, TranspositionEntity* newEntry, U64 key) {
-    int replacePriorities[1];
+void replaceTranspositionEntry(Transposition* addr, Transposition* newEntry, U64 key) {
+    int shouldReplace = 0;
 
-    if(addr->entity[0].age + 5 < ttAge || !addr->entity[0].evalType) {
-        replacePriorities[0] = MAX_PLY * 2 - addr->entity[0].depth;
+    if(addr->age + 5 < ttAge || !addr->evalType) {
+        shouldReplace = 1;
     } else {
-        if(newEntry->depth >= addr->entity[0].depth) {
-            if(newEntry->evalType == upperbound && addr->entity[0].evalType != upperbound) {
-                replacePriorities[0] = -1;
+        if(newEntry->depth >= addr->depth) {
+            if(newEntry->evalType == upperbound && addr->evalType != upperbound) {
+                shouldReplace = 0;
             } else {
-                replacePriorities[0] = MAX_PLY * 2 - addr->entity[0].depth;
+                shouldReplace = 1;
             }
         }
     }
 
-    int index = -1;
-    int maxPriority = -1;
+    if (shouldReplace) {
+        *addr = *newEntry;
 
-    if (replacePriorities[0] > maxPriority) {
-        index = 0;
-        maxPriority = replacePriorities[0];
-    }
-
-    if (index != -1) {
-        if (!addr->entity[index].evalType) {
+        if (!addr->evalType) {
             ttFilledSize++;
         }
-
-        addr->entity[index] = *newEntry;
     }
 }
 
@@ -87,16 +79,4 @@ int evalFromTT(int eval, int height) {
         return eval + height;
         
     return eval;
-}
-
-int getMaxDepthBucket(Transposition* entry, U64 key) {
-    uint32_t depth = 0;
-    int result = -1;
-
-    if (entry->entity[0].depth > depth && key == entry->entity[0].key) {
-        depth = entry->entity[0].depth;
-        result = 0;
-    }
-
-    return result;
 }

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -29,37 +29,31 @@ void clearTT() {
 }
 
 void replaceTranspositionEntry(Transposition* addr, TranspositionEntity* newEntry, U64 key) {
-    int replacePriorities[BUCKETS_N];
+    int replacePriorities[1];
 
-    for (int i = 0; i < BUCKETS_N; ++i) {
-        if(addr->entity[i].age + 5 < ttAge || !addr->entity[i].evalType) {
-            replacePriorities[i] = MAX_PLY * 2 - addr->entity[i].depth;
-            continue;
-        }
-
-        if(newEntry->depth >= addr->entity[i].depth) {
-            if(newEntry->evalType == upperbound && addr->entity[i].evalType != upperbound) {
-                replacePriorities[i] = -1;
-                continue;
+    if(addr->entity[0].age + 5 < ttAge || !addr->entity[0].evalType) {
+        replacePriorities[0] = MAX_PLY * 2 - addr->entity[0].depth;
+    } else {
+        if(newEntry->depth >= addr->entity[0].depth) {
+            if(newEntry->evalType == upperbound && addr->entity[0].evalType != upperbound) {
+                replacePriorities[0] = -1;
+            } else {
+                replacePriorities[0] = MAX_PLY * 2 - addr->entity[0].depth;
             }
-
-            replacePriorities[i] = MAX_PLY * 2 - addr->entity[i].depth;
         }
     }
 
     int index = -1;
     int maxPriority = -1;
 
-    for (int i = 0; i < BUCKETS_N; ++i) {
-        if (replacePriorities[i] > maxPriority) {
-            index = i;
-            maxPriority = replacePriorities[i];
-        }
+    if (replacePriorities[0] > maxPriority) {
+        index = 0;
+        maxPriority = replacePriorities[0];
     }
 
     if (index != -1) {
         if (!addr->entity[index].evalType) {
-            ttFilledSize += 1. / BUCKETS_N;
+            ttFilledSize++;
         }
 
         addr->entity[index] = *newEntry;
@@ -99,11 +93,9 @@ int getMaxDepthBucket(Transposition* entry, U64 key) {
     uint32_t depth = 0;
     int result = -1;
 
-    for (int i = 0; i < BUCKETS_N; ++i) {
-        if (entry->entity[i].depth > depth && key == entry->entity[i].key) {
-            depth = entry->entity[i].depth;
-            result = i;
-        }
+    if (entry->entity[0].depth > depth && key == entry->entity[0].key) {
+        depth = entry->entity[0].depth;
+        result = 0;
     }
 
     return result;

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -10,7 +10,7 @@
 #include "bitboards.h"
 
 enum {
-    BUCKETS_N = 2,
+    BUCKETS_N = 1,
 };
 
 struct TranspositionEntity {

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -9,10 +9,6 @@
 #include "types.h"
 #include "bitboards.h"
 
-enum {
-    BUCKETS_N = 1,
-};
-
 struct TranspositionEntity {
     S16 eval;
     U8 depth;
@@ -23,7 +19,7 @@ struct TranspositionEntity {
 };
 
 struct Transposition {
-    TranspositionEntity entity[BUCKETS_N];
+    TranspositionEntity entity[1];
 };
 
 Transposition* tt;

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -9,17 +9,13 @@
 #include "types.h"
 #include "bitboards.h"
 
-struct TranspositionEntity {
+struct Transposition {
     S16 eval;
     U8 depth;
     S8 age;
     U8 evalType;
     U16 move;
     U64 key;
-};
-
-struct Transposition {
-    TranspositionEntity entity[1];
 };
 
 Transposition* tt;
@@ -31,10 +27,9 @@ int ttAge;
 void initTT(int size);
 void reallocTT(int size);
 void clearTT();
-void replaceTranspositionEntry(Transposition* addr, TranspositionEntity* newEntry, U64 key);
+void replaceTranspositionEntry(Transposition* addr, Transposition* newEntry, U64 key);
 U64 sizeToTTCount(U64 size);
 int evalToTT(int eval, int height);
 int evalFromTT(int eval, int height);
-int getMaxDepthBucket(Transposition* entry, U64 key);
 
 #endif

--- a/src/types.h
+++ b/src/types.h
@@ -55,7 +55,6 @@ typedef struct SearchInfo SearchInfo;
 typedef struct GameInfo GameInfo;
 typedef struct Timer Timer;
 typedef struct TimeManager TimeManager;
-typedef struct TranspositionEntity TranspositionEntity;
 typedef struct Transposition Transposition;
 typedef struct SearchArgs SearchArgs;
 typedef struct Option Option;

--- a/src/uci.c
+++ b/src/uci.c
@@ -239,20 +239,14 @@ void printPV(Board* board, int depth, U16 bestMove) {
     Transposition* cur = &tt[board->key & ttIndex];
     
     for(int i = 0; !isDraw(board) && i < depth + 20; ++i) {
-        int entityIndex = getMaxDepthBucket(cur, board->key);
-
-        if (entityIndex == -1) {
+        if (!cur->evalType) {
             break;
         }
 
-        TranspositionEntity entity = cur->entity[entityIndex];
-
-        // (cur->evalType == lowerbound || cur->evalType == exact) &&
-
-        moveToString(entity.move, mv);
+        moveToString(cur->move, mv);
 
         if(findMove(mv, board)) {
-            makeMove(board, entity.move, &undo);
+            makeMove(board, cur->move, &undo);
             if(inCheck(board, !board->color))
                 break;
             printf("%s ", mv);


### PR DESCRIPTION
Remove buckets, because there are no improvement for now

```
tc=1+0.01
Score of Zevra Dev vs Zevra Base: 1762 - 1589 - 1650  [0.517] 5001
Elo difference: 12.0 +/- 7.9, LOS: 99.9 %, DrawRatio: 33.0 %
SPRT: llr 2.94 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted
```